### PR TITLE
Change require's to allow for alternate base directory name

### DIFF
--- a/tasks/copy.lua
+++ b/tasks/copy.lua
@@ -8,7 +8,7 @@
 
 --]]
 
-require('../../ntm')
+require('../')
 require('./util')
 require('optim')
 require('sys')

--- a/tasks/recall.lua
+++ b/tasks/recall.lua
@@ -16,7 +16,7 @@
 
 --]]
 
-require('../../ntm')
+require('../')
 require('./util')
 require('sys')
 

--- a/tests/test-circular.lua
+++ b/tests/test-circular.lua
@@ -1,4 +1,4 @@
-require('../../ntm')
+require('../')
 require('torch')
 require('nn')
 require('sys')

--- a/tests/test-cosine.lua
+++ b/tests/test-cosine.lua
@@ -1,4 +1,4 @@
-require('../../ntm')
+require('../')
 require('torch')
 require('nn')
 

--- a/tests/test-normalize.lua
+++ b/tests/test-normalize.lua
@@ -1,4 +1,4 @@
-require('../../ntm')
+require('../')
 require('torch')
 require('nn')
 require('sys')

--- a/tests/test-outer.lua
+++ b/tests/test-outer.lua
@@ -1,4 +1,4 @@
-require('../../ntm')
+require('../')
 require('torch')
 require('nn')
 

--- a/tests/test-scalartables.lua
+++ b/tests/test-scalartables.lua
@@ -1,4 +1,4 @@
-require('../../ntm')
+require('../')
 
 local v = torch.Tensor{1,2,3}
 local c = torch.Tensor{1.5}


### PR DESCRIPTION
Hi!

When downloading the folder name is torch-ntm; however the directory name specified in the require is ntm. 
This change modifies the requires in tests and tasks so that regardless of the base directory name the require will work. 
